### PR TITLE
reorganize external dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,16 +22,6 @@
     <NetCoreAppVersion>netcoreapp2.2</NetCoreAppVersion>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <AkkaVersion>1.4.17</AkkaVersion>
-    <AkkaPersistenceVersion>1.4.17</AkkaPersistenceVersion>
-    <AkkaPersistenceQueryVersion>1.4.17</AkkaPersistenceQueryVersion>
-    <AkkaRemoteVersion>1.4.17</AkkaRemoteVersion>
-    <AkkaRemoteTestKitVersion>1.4.17</AkkaRemoteTestKitVersion>
-    <AkkaClusterVersion>1.4.17</AkkaClusterVersion>
-    <AkkaClusterShardingVersion>1.4.17</AkkaClusterShardingVersion>
-    <AkkaClusterToolsVersion>1.4.17</AkkaClusterToolsVersion>
-    <AkkaTestKitVersion>1.4.17</AkkaTestKitVersion>
-    <AkkaClusterTestKitVersion>1.4.17</AkkaClusterTestKitVersion>
-    <AkkaTestKitXunitVersion>1.4.17</AkkaTestKitXunitVersion>
     <AkkatectureMultiNodeSharedVersion>0.5.2</AkkatectureMultiNodeSharedVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitRunnerVSVersion>2.4.3</XunitRunnerVSVersion>

--- a/src/Akkatecture.Clustering/Akkatecture.Clustering.csproj
+++ b/src/Akkatecture.Clustering/Akkatecture.Clustering.csproj
@@ -28,10 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster" Version="$(AkkaClusterVersion)" />
-    <PackageReference Include="Akka.Cluster.Sharding" Version="$(AkkaClusterShardingVersion)" />
-    <PackageReference Include="Akka.Cluster.Tools" Version="$(AkkaClusterToolsVersion)" />
-    <PackageReference Include="Akka.Persistence" Version="$(AkkaPersistenceVersion)" />
+    <PackageReference Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGithubVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Akkatecture.TestFixture/Akkatecture.TestFixture.csproj
+++ b/src/Akkatecture.TestFixture/Akkatecture.TestFixture.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGithubVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Akkatecture/Akkatecture.csproj
+++ b/src/Akkatecture/Akkatecture.csproj
@@ -25,9 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Persistence" Version="$(AkkaPersistenceVersion)" />
-    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaPersistenceQueryVersion)" />
+    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageReference Include="Cronos" Version="0.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGithubVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/test/Akkatecture.MultiNodeTestRunner/Akkatecture.MultiNodeTestRunner.csproj
+++ b/test/Akkatecture.MultiNodeTestRunner/Akkatecture.MultiNodeTestRunner.csproj
@@ -11,12 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaClusterTestKitVersion)" />
-    <PackageReference Include="Akka.Remote" Version="$(AkkaRemoteVersion)" />
-    <PackageReference Include="Akka.Remote.TestKit" Version="$(AkkaRemoteTestKitVersion)" />
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaTestKitXunitVersion)" />
+    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitRunnerUtilityVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildVersion)" />

--- a/test/Akkatecture.NodeTestRunner/Akkatecture.NodeTestRunner.csproj
+++ b/test/Akkatecture.NodeTestRunner/Akkatecture.NodeTestRunner.csproj
@@ -11,11 +11,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Remote" Version="$(AkkaRemoteVersion)" />
-    <PackageReference Include="Akka.Remote.TestKit" Version="$(AkkaRemoteTestKitVersion)" />
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaTestKitXunitVersion)" />
+    <PackageReference Include="Akka.Remote.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitRunnerUtilityVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildVersion)" />
     <PackageReference Include="Akkatecture.MultiNode.Shared" Version="$(AkkatectureMultiNodeSharedVersion)" />

--- a/test/Akkatecture.TestHelpers/Akkatecture.TestHelpers.csproj
+++ b/test/Akkatecture.TestHelpers/Akkatecture.TestHelpers.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>  
   
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" PrivateAssets="All" />
   </ItemGroup> 
 </Project>

--- a/test/Akkatecture.TestHelpers/Akkatecture.TestHelpers.csproj
+++ b/test/Akkatecture.TestHelpers/Akkatecture.TestHelpers.csproj
@@ -23,10 +23,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Akkatecture.TestFixture\Akkatecture.TestFixture.csproj" />
     <ProjectReference Include="..\..\src\Akkatecture\Akkatecture.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaTestKitVersion)" />
-  </ItemGroup> 
-  
+  </ItemGroup>  
 </Project>

--- a/test/Akkatecture.Tests.MultiNode/Akkatecture.Tests.MultiNode.csproj
+++ b/test/Akkatecture.Tests.MultiNode/Akkatecture.Tests.MultiNode.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaClusterTestKitVersion)" />
+    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/test/Akkatecture.Tests/Akkatecture.Tests.csproj
+++ b/test/Akkatecture.Tests/Akkatecture.Tests.csproj
@@ -20,9 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaClusterTestKitVersion)" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaTestKitXunitVersion)" />
+    <PackageReference Include="Akka.Cluster.TestKit" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />


### PR DESCRIPTION
Should allow Dependabot to play nicely with Akkatecture - only pull in the highest-kinded dependencies and let all else be taken in as transitive ones.