### PR TITLE
embed `README.md` into NuGet file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsPackable>false</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
     
   <PropertyGroup>


### PR DESCRIPTION
This change will cause the `README.md` file in this repository to be displayed as the `README` field on https://nuget.org for all Akkatecture packages.