### PR TITLE
Dependabot/nuget/microsoft.extensions.dependency injection.abstractions 6.0.0

### DIFF
--- a/examples/web/Akkatecture.Examples.Api/Akkatecture.Examples.Api.csproj
+++ b/examples/web/Akkatecture.Examples.Api/Akkatecture.Examples.Api.csproj
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/examples/web/Akkatecture.Examples.Api/Akkatecture.Examples.Api.csproj
+++ b/examples/web/Akkatecture.Examples.Api/Akkatecture.Examples.Api.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
   

--- a/examples/web/Akkatecture.Examples.Api/Startup.cs
+++ b/examples/web/Akkatecture.Examples.Api/Startup.cs
@@ -56,11 +56,10 @@ namespace Akkatecture.Examples.Api
                 .AddActorReference<ResourceCreationSagaManager>(sagaManager)
                 .AddActorReference<ResourcesStorageHandler>(resourceStorage)
                 .AddActorReference<OperationsStorageHandler>(operationStorage);
-            
-            services
-                .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
+            services.AddMvc();
+            services.AddControllers();
+            
             // Add Read Side 
             services
                 .AddTransient<IQueryResources, ResourcesQueryHandler>()
@@ -71,17 +70,13 @@ namespace Akkatecture.Examples.Api
             IApplicationBuilder app,
             ILoggerFactory loggerFactory)
         {
-
             app.Map("/api", api =>
-            {
-                api.UseMvc(routes =>
+            api.UseRouting()
+                .UseEndpoints(endpoints =>
                 {
-                    routes.MapRoute(
-                        name: "default",
-                        template: "{controller}/{action}");
-                });
-            });
-            
+                    endpoints.MapControllerRoute(name: "default",
+                        pattern: "{controller}/{action}");
+                })); 
             
             var logger = loggerFactory.CreateLogger<Startup>();
             logger.LogInformation("Akkatecture.Examples.Api application has initialized.");

--- a/src/Akkatecture/Akkatecture.csproj
+++ b/src/Akkatecture/Akkatecture.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Cronos" Version="0.7.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGithubVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
A commit I added to the change from Dependabot fixes the Web.API example, broken after changing to net6.0