### PR TITLE
add ICommandResult with associated classes, tests (issue 47)

### DIFF
--- a/Akkatecture.sln.DotSettings
+++ b/Akkatecture.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Akkatecture/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akkatecture/Aggregates/CommandResults/CommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/CommandResult.cs
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+//     Modified from original source https://github.com/eventflow/EventFlow
+// Copyright (c) 2018 - 2021 Lutando Ngqakaza
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akketecture
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using Akkatecture.Commands;
+
+namespace Akkatecture.Aggregates.CommandResults;
+
+public class CommandResult : ICommandResult
+{
+    public static ICommandResult SucceedWith(ICommand command) =>
+        new SuccessCommandResult(command.GetSourceId().Value);
+    public static ICommandResult SucceedWith(string commandId) =>
+        new SuccessCommandResult(commandId);
+    public static ICommandResult FailWith(ICommand command, params string[] errors) =>
+        new FailedCommandResult(command.GetSourceId().Value, errors);
+    public static ICommandResult FailWith(string commandId, params string[] errors) =>
+        new FailedCommandResult(commandId, errors);
+    public static ICommandResult FailWith(ICommand command, IEnumerable<string> errors) =>
+        new FailedCommandResult(command.GetSourceId().Value, errors);
+    public static ICommandResult FailWith(string commandId, IEnumerable<string> errors) =>
+        new FailedCommandResult(commandId, errors);
+
+    protected CommandResult(string commandId, bool isSuccess)
+    {
+        IsSuccess = isSuccess;
+        CommandId = new CommandId(commandId);
+    }
+
+    public ICommandId CommandId { get; }
+    public bool IsSuccess { get; }
+}

--- a/src/Akkatecture/Aggregates/CommandResults/CommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/CommandResult.cs
@@ -5,7 +5,7 @@
 //     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/Akkatecture/Aggregates/CommandResults/FailedCommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/FailedCommandResult.cs
@@ -5,7 +5,7 @@
 //     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/Akkatecture/Aggregates/CommandResults/FailedCommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/FailedCommandResult.cs
@@ -1,8 +1,12 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 //
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+//     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
-// https://github.com/Lutando/Akkatecture 
-// 
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -21,21 +25,24 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using Akkatecture.Commands;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace Akkatecture.TestHelpers.Aggregates.Commands
+namespace Akkatecture.Aggregates.CommandResults;
+
+public class FailedCommandResult : CommandResult
 {
-    public class CreateTestCommand : Command<TestAggregate, TestAggregateId>
+    public IReadOnlyCollection<string> Errors { get; }
+        
+    public FailedCommandResult(string sourceId, IEnumerable<string> errors):base(sourceId, false)
     {
-        public CreateTestCommand(
-            TestAggregateId aggregateId,
-            CommandId sourceId)
-            : base(aggregateId, sourceId)
-        {
-        }
-
-        public CreateTestCommand(TestAggregateId aggregateId) : base(aggregateId)
-        {
-        }
+        Errors = (errors ?? Enumerable.Empty<string>()).ToList();
+    }
+            
+    public override string ToString()
+    {
+        return Errors.Any()
+            ? $"Failed execution for command {CommandId} due to: {string.Join(", ", Errors)}"
+            : $"Failed execution for command {CommandId}";
     }
 }

--- a/src/Akkatecture/Aggregates/CommandResults/ICommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/ICommandResult.cs
@@ -1,8 +1,12 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 //
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+//     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
-// https://github.com/Lutando/Akkatecture 
-// 
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -21,21 +25,12 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using Akkatecture.Aggregates.ExecutionResults;
 using Akkatecture.Commands;
 
-namespace Akkatecture.TestHelpers.Aggregates.Commands
-{
-    public class CreateTestCommand : Command<TestAggregate, TestAggregateId>
-    {
-        public CreateTestCommand(
-            TestAggregateId aggregateId,
-            CommandId sourceId)
-            : base(aggregateId, sourceId)
-        {
-        }
+namespace Akkatecture.Aggregates.CommandResults;
 
-        public CreateTestCommand(TestAggregateId aggregateId) : base(aggregateId)
-        {
-        }
-    }
+public interface ICommandResult: IExecutionResult
+{
+    ICommandId CommandId { get; }
 }

--- a/src/Akkatecture/Aggregates/CommandResults/ICommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/ICommandResult.cs
@@ -5,7 +5,7 @@
 //     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/Akkatecture/Aggregates/CommandResults/SuccessCommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/SuccessCommandResult.cs
@@ -5,7 +5,7 @@
 //     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/Akkatecture/Aggregates/CommandResults/SuccessCommandResult.cs
+++ b/src/Akkatecture/Aggregates/CommandResults/SuccessCommandResult.cs
@@ -1,8 +1,12 @@
-﻿// The MIT License (MIT)
+// The MIT License (MIT)
 //
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+//     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
-// https://github.com/Lutando/Akkatecture 
-// 
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akketecture
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -21,21 +25,18 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using Akkatecture.Commands;
 
-namespace Akkatecture.TestHelpers.Aggregates.Commands
+namespace Akkatecture.Aggregates.CommandResults;
+
+public class SuccessCommandResult : CommandResult
 {
-    public class CreateTestCommand : Command<TestAggregate, TestAggregateId>
-    {
-        public CreateTestCommand(
-            TestAggregateId aggregateId,
-            CommandId sourceId)
-            : base(aggregateId, sourceId)
-        {
-        }
 
-        public CreateTestCommand(TestAggregateId aggregateId) : base(aggregateId)
-        {
-        }
+    public SuccessCommandResult(string commandId) : base(commandId, true)
+    {
+    }
+
+    public override string ToString()
+    {
+        return $"Command {CommandId} executed successfully";
     }
 }

--- a/test/Akkatecture.TestHelpers/Aggregates/Commands/CreateTestCommand.cs
+++ b/test/Akkatecture.TestHelpers/Aggregates/Commands/CreateTestCommand.cs
@@ -33,8 +33,12 @@ namespace Akkatecture.TestHelpers.Aggregates.Commands
             : base(aggregateId, sourceId)
         {
         }
+    }
 
-        public CreateTestCommand(TestAggregateId aggregateId) : base(aggregateId)
+    public class CreateTestCommandRequestingCommandResult : Command<TestAggregate, TestAggregateId>
+    {
+        public CreateTestCommandRequestingCommandResult(TestAggregateId aggregateId, CommandId sourceId)
+            : base(aggregateId, sourceId)
         {
         }
     }

--- a/test/Akkatecture.TestHelpers/Aggregates/Sagas/Test/TestSaga.cs
+++ b/test/Akkatecture.TestHelpers/Aggregates/Sagas/Test/TestSaga.cs
@@ -62,10 +62,10 @@ namespace Akkatecture.TestHelpers.Aggregates.Sagas.Test
                     domainEvent.AggregateEvent.Test);
                 
                 RequestTimeout(new TestSagaTimeout("First timeout test"),
-                    TimeSpan.FromSeconds(5));
+                    TimeSpan.FromSeconds(3));
 
                 RequestTimeout(new TestSagaTimeout2("Second timeout test; handled asynchronously"),
-                    TimeSpan.FromSeconds(10));
+                    TimeSpan.FromSeconds(12));
                 
                 Emit(new TestSagaStartedEvent(domainEvent.AggregateIdentity,
                     domainEvent.AggregateEvent.RecipientAggregateId, domainEvent.AggregateEvent.Test));

--- a/test/Akkatecture.Tests/UnitTests/Commands/CommandResultTests.cs
+++ b/test/Akkatecture.Tests/UnitTests/Commands/CommandResultTests.cs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akkatecture 
 // 
 // 

--- a/test/Akkatecture.Tests/UnitTests/Commands/CommandResultTests.cs
+++ b/test/Akkatecture.Tests/UnitTests/Commands/CommandResultTests.cs
@@ -1,0 +1,132 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 - 2021 Lutando Ngqakaza
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akkatecture 
+// 
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+using System.Collections.Generic;
+using Akkatecture.Aggregates.CommandResults;
+using Akkatecture.TestHelpers.Aggregates;
+using Akkatecture.TestHelpers.Aggregates.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace Akkatecture.Tests.UnitTests.Commands;
+
+public class CommandResultTests
+{
+     [Fact]
+     public void SuccessCommandResults_Should_Show_Success_Using_IIdentity()
+     {
+         var id = TestAggregateId.New;
+         var createTest = new CreateTestCommand(id); 
+        
+         // Pass ICommand as param
+         var commandResult = CommandResult.SucceedWith(createTest);
+         commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+         commandResult.IsSuccess.Should().BeTrue();
+     }
+     
+    [Fact]
+    public void SuccessCommandResults_Should_Show_Success_Using_String()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass string as param
+        var commandResult = CommandResult.SucceedWith(createTest.SourceId.Value);
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void FailedCommandResults_Should_Show_Failure_Using_String_Array()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass List of errors
+        var errorArray = new List<string> { "something bad", "very bad" };
+        
+        // Pass string for sourceId
+        var commandResult = CommandResult.FailWith(createTest.SourceId.ToString(), errorArray);
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeFalse();
+        commandResult.ToString().Should().ContainAll("Failed", createTest.SourceId.Value, "something bad", "very bad");
+    }
+    
+    [Fact]
+    public void FailedCommandResults_Should_Show_Failure_Using_Multiple_Strings()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass string for CommandId
+        // Pass multiple string for error messages
+        var commandResult = CommandResult.FailWith(createTest.SourceId.Value, "something bad", "very bad");
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeFalse();
+        commandResult.ToString().Should().ContainAll("Failed", createTest.SourceId.Value, "something bad", "very bad");
+    }
+
+    [Fact]
+    public void FailedCommandResults_From_Command_Should_Show_Failure_Using_Multiple_Strings()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass multiple string for error messages
+        var commandResult = CommandResult.FailWith(createTest, "something bad", "very bad");
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeFalse();
+        commandResult.ToString().Should().ContainAll("Failed", createTest.SourceId.Value, "something bad", "very bad");
+    }
+    
+    [Fact]
+    public void FailedCommandResults_Should_Show_Failure_Without_Errors_Supplied()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass IIdentity for sourceId
+        // Pass nothing for error messages
+        var commandResult = CommandResult.FailWith(createTest.SourceId.Value);
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeFalse();
+        commandResult.ToString().Should().Contain($"Failed execution for command {createTest.SourceId}");
+    }    
+    
+    [Fact]
+    public void FailedCommandResults_From_Command_Should_Show_Failure_Without_Errors_Supplied()
+    {
+        var id = TestAggregateId.New;
+        var createTest = new CreateTestCommand(id); 
+
+        // Pass IIdentity for sourceId
+        // Pass nothing for error messages
+        var commandResult = CommandResult.FailWith(createTest, new List<string>());
+        commandResult.CommandId.Should().BeEquivalentTo(createTest.SourceId);
+        commandResult.IsSuccess.Should().BeFalse();
+        commandResult.ToString().Should().Contain($"Failed execution for command {createTest.SourceId}");
+    }
+}

--- a/test/Akkatecture.Tests/UnitTests/Commands/CommandTests.cs
+++ b/test/Akkatecture.Tests/UnitTests/Commands/CommandTests.cs
@@ -1,3 +1,28 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 - 2021 Lutando Ngqakaza
+//     https://github.com/Lutando/Akkatecture 
+// Copyright (c) 2022 AfterLutz contributors
+//     https://github.com/AfterLutz/Akkatecture 
+// 
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using System;
 using Akkatecture.Commands;
 using Akkatecture.TestHelpers.Aggregates;

--- a/test/Akkatecture.Tests/UnitTests/Commands/CommandTests.cs
+++ b/test/Akkatecture.Tests/UnitTests/Commands/CommandTests.cs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
 //     https://github.com/Lutando/Akkatecture 
-// Copyright (c) 2022 AfterLutz contributors
+// Copyright (c) 2022 AfterLutz Contributors
 //     https://github.com/AfterLutz/Akkatecture 
 // 
 // 


### PR DESCRIPTION
I've added an interface and implementations to allow for returning a CommandId with an ExecutionResult. These implementations follow a pattern already found in the tests. 