### PR TITLE
ActorRefProvider - feat: allow mocking of ActorRefProvider

### DIFF
--- a/src/Akkatecture/Akka/ActorRefProvider.cs
+++ b/src/Akkatecture/Akka/ActorRefProvider.cs
@@ -1,19 +1,23 @@
 ﻿// The MIT License (MIT)
 //
+// Copyright (c) 2015-2021 Rasmus Mikkelsen
+// Copyright (c) 2015-2021 eBay Software Foundation
+//     Modified from original source https://github.com/eventflow/EventFlow
 // Copyright (c) 2018 - 2021 Lutando Ngqakaza
-// https://github.com/Lutando/Akkatecture 
-// 
-// 
+//     https://github.com/Lutando/Akkatecture
+// Copyright (c) 2022 AfterLutz Contributors
+//     https://github.com/AfterLutz/Akketecture
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -28,68 +32,44 @@ using Akka.Actor;
 
 namespace Akkatecture.Akka
 {
-    public class ActorRefProvider<T> : ActorRefProvider
-    {
-        public ActorRefProvider(IActorRef actorRef)
-            : base(actorRef)
-        {
-        }
-    }
-
     public abstract class ActorRefProvider
     {
         public IActorRef ActorRef { get; }
+
         protected ActorRefProvider(IActorRef actorRef)
-        {
-            ActorRef = actorRef;
-        }
+            => ActorRef = actorRef;
+
+        public virtual void Tell(object message, IActorRef sender)
+            => ActorRef.Tell(message, sender);
+
+        public virtual void Tell(object message)
+            => ActorRef.Tell(message, ActorRefs.NoSender);
+
+        public virtual Task<object> Ask(object message, TimeSpan? timeout = null)
+            => ActorRef.Ask(message, timeout);
+
+        public virtual Task<object> Ask(object message, CancellationToken cancellationToken)
+            => ActorRef.Ask(message, cancellationToken);
+
+        public virtual Task<object> Ask(object message, TimeSpan? timeout, CancellationToken cancellationToken)
+            => ActorRef.Ask(message, timeout, cancellationToken);
+
+        public virtual Task<T> Ask<T>(object message, TimeSpan? timeout = null)
+            => ActorRef.Ask<T>(message, timeout);
+
+        public virtual Task<T> Ask<T>(object message, CancellationToken cancellationToken)
+            => ActorRef.Ask<T>(message, cancellationToken);
+
+        public virtual Task<T> Ask<T>(object message, TimeSpan? timeout, CancellationToken cancellationToken)
+            => ActorRef.Ask<T>(message, timeout, cancellationToken);
+
+        public virtual Task<T> Ask<T>(Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
+            => ActorRef.Ask<T>(messageFactory, timeout, cancellationToken);
     }
 
-    public static class ActorRefProviderExtensions
+    public class ActorRefProvider<T> : ActorRefProvider
     {
-        public static void Tell(this ActorRefProvider provider, object message, IActorRef sender)
-        {
-            provider.ActorRef.Tell(message, sender);
-        }
-        
-        public static void Tell(this ActorRefProvider provider, object message)
-        {
-            provider.ActorRef.Tell(message, ActorRefs.NoSender);
-        }
-
-        public static Task<object> Ask(this ActorRefProvider provider, object message, TimeSpan? timeout = null)
-        {
-            return provider.ActorRef.Ask(message, timeout);
-        }
-
-        public static Task<object> Ask(this ActorRefProvider provider, object message, CancellationToken cancellationToken)
-        {
-            return provider.ActorRef.Ask(message, cancellationToken);
-        }
-
-        public static Task<object> Ask(this ActorRefProvider provider, object message, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            return provider.ActorRef.Ask(message, timeout, cancellationToken);
-        }
-
-        public static Task<T> Ask<T>(this ActorRefProvider provider, object message, TimeSpan? timeout = null)
-        {
-            return provider.ActorRef.Ask<T>(message, timeout);
-        }
-
-        public static Task<T> Ask<T>(this ActorRefProvider provider, object message, CancellationToken cancellationToken)
-        {
-            return provider.ActorRef.Ask<T>(message, cancellationToken);
-        }
-
-        public static Task<T> Ask<T>(this ActorRefProvider provider, object message, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            return provider.ActorRef.Ask<T>(message, timeout, cancellationToken);
-        }
-
-        public static Task<T> Ask<T>(this ActorRefProvider provider, Func<IActorRef, object> messageFactory, TimeSpan? timeout, CancellationToken cancellationToken)
-        {
-            return provider.ActorRef.Ask<T>(messageFactory, timeout, cancellationToken);
-        }
+        public ActorRefProvider(IActorRef actorRef)
+            : base(actorRef) { }
     }
 }


### PR DESCRIPTION
Extension methods are hard to mock with `Moq`. There is no point having them as extension methods when you control the object itself, in the same file, in the same lib.